### PR TITLE
Add App_type header to fix Invalid appid error

### DIFF
--- a/api_client.py
+++ b/api_client.py
@@ -141,6 +141,7 @@ class SpeedianceClient:
         headers = {
             "Host": self.host,
             "User-Agent": "Dart/3.9 (dart:io)",
+            "App_type": "SOFTWARE",
             "Content-Type": "application/json",
             "Timestamp": str(int(time.time() * 1000)),
             "Utc_offset": "+0000",
@@ -233,7 +234,8 @@ class SpeedianceClient:
             "Versioncode": "40304",
             "Mobiledevices": '{"brand":"google","device":"emulator64_x86_64_arm64","deviceType":"sdk_gphone64_x86_64","os":"","os_version":"31","manufacturer":"Google"}',
             "Content-Type": "application/json",
-            "User-Agent": "Dart/3.9 (dart:io)"
+            "User-Agent": "Dart/3.9 (dart:io)",
+            "App_type": "SOFTWARE"
         }
 
     def get_categories(self):


### PR DESCRIPTION
## Summary

As of 2026-03-25, Speediance is enforcing the `App_type: SOFTWARE` header on all API endpoints. Requests without it now return `{"code":1002,"message":"Invalid appid"}`.

`login()` and `logout()` already include this header, but `_get_headers()` — used by all other authenticated API calls — does not. This one-line addition fixes it.

## What changed

- Added `"App_type": "SOFTWARE"` to the `_get_headers()` return dict in `api_client.py`

## How I found this

Tested each header individually against the live EU API (`euapi.speediance.com`). `App_type: SOFTWARE` is the sole new requirement — all other existing headers remain unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)